### PR TITLE
Skip 021_jmcBundled.sh on el10

### DIFF
--- a/tests/021_jmcBundled.sh
+++ b/tests/021_jmcBundled.sh
@@ -20,8 +20,9 @@ if ! isRedHatDistro ; then
   exit 0
 fi
 
-if [ "$OTOOL_OS_VERSION" -ge "35" ] ; then
-  echo "$SKIPPED_jmc_decom_fedora"
+if [ "x$OTOOL_OS_NAME" = "xf" -a "$OTOOL_OS_VERSION" -ge "35" ] \
+|| [ "x$OTOOL_OS_NAME" = "xel" -a "$OTOOL_OS_VERSION" -ge "10" ] ; then
+  echo "$SKIPPED_jmc_decom"
   exit 0
 fi
 

--- a/tests/testlib.bash
+++ b/tests/testlib.bash
@@ -27,7 +27,7 @@ SKIPPED_MSI_LINUX="!skipped! no testing of msi on linux !skipped!"
 SKIPPED_itw_jdk16="!skipped! itw 1.7 seems to support jdk11 but is.. well old !skipped!"
 SKIPPED_jdk_needed="!skipped! this test requires jdk, you are most likely on jre(-headless) !skipped!"
 SKIPPED_jdk11_sdk="!skipped! On JDK11+, netbeans requires JDK, this looks to be JRE !skipped!"
-SKIPPED_jmc_decom_fedora="!skipped! jmc is no longer packed for fedora !skipped!"
+SKIPPED_jmc_decom="!skipped! jmc is no longer packed for fedora and el10 !skipped!"
 SKIPPED_el9="!skipped! no op on el9 !skipped!"
 SKIPPED_no_RH="!skipped! requires Red Hat distro !skipped!"
 


### PR DESCRIPTION
Jmc package has been [retired](https://gitlab.com/redhat/centos-stream/rpms/jmc/-/commit/188771ab63df839b6131b99e469cba17d0f37501) on el10.