### PR TITLE
GHA fix: pack results in case of failure

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -62,6 +62,7 @@ jobs:
           cat workspace/results/results.txt
           grep '^rhqa.failed=0$' workspace/results/results.properties
       - name: Pack results
+        if: ${{ always() }}
         run: |
           tar -czf results.tar.gz -C workspace results
       - name: Upload results


### PR DESCRIPTION
Added forgotten `if: ${{ always() }}` to pack results even in case of failure.