### PR TITLE
Fix compareImagesSilently error when diff is zero

### DIFF
--- a/tests/testlib.bash
+++ b/tests/testlib.bash
@@ -281,7 +281,7 @@ function compareImagesSilently() {
   echo "40+ same, 10- different" 1>&2
   # shellcheck disable=SC2155
   # shellcheck disable=SC2002
-  local diff=$(cat "$REPORT_DIR"/res-"$idCompOverride" | sed "s;\\..*;;")
+  local diff=$(cat "$REPORT_DIR"/res-"$idCompOverride" | sed "s;[. ].*;;")
   if [ "$diff" == "inf" ] ; then
     local diff=50 #same
   fi


### PR DESCRIPTION
Error (found in GHA runs):
```
2025-04-18T07:46:22.3089861Z /home/runner/work/GUITests/GUITests/tests/testlib.bash: line 256: [: 0 (0): integer expression expected
```

Seems like current sed expression strips part of compare output starting with decimal dot, but fails if there no decimal dot (in case of `0 (0)`).

Fix:
Updated to strip part starting with dot or space.