### PR TITLE
Workaround problem of psnr not using inf for identical images anymore

### DIFF
--- a/tests/testlib.bash
+++ b/tests/testlib.bash
@@ -282,6 +282,12 @@ function compareImagesSilently() {
   # shellcheck disable=SC2155
   # shellcheck disable=SC2002
   local diff=$(cat "$REPORT_DIR"/res-"$idCompOverride" | sed "s;[. ].*;;")
+  # behavior of psnr has changed, zero is now reported instead of "inf":
+  # https://www.imagemagick.org/discourse-server/viewtopic.php?t=31487
+  # distinguish "inf" case using AE metric to emulate previous behavior
+  if [ "$diff" -eq 0 ] && compare -metric AE "$REPORT_DIR"/"$name"-"$id1".png "$REPORT_DIR"/"$name"-"$id2".png null: 2>&1 | grep -q '^0' ; then
+    diff="inf"
+  fi
   if [ "$diff" == "inf" ] ; then
     local diff=50 #same
   fi


### PR DESCRIPTION
Behavior of psnr metric has changed. Now returns 0. where previously returned inf. (see my [previous comment](https://github.com/rh-openjdk/GUITests/pull/26#issuecomment-2835809589))

Workaround:
Use additional check using AE metric (number of different pixels) to distinguish, what was previously inf case (identical), from genuine 0 (max difference).