### PR TITLE
Disable opening of donate page by eclipse

### DIFF
--- a/tests/testlib.bash
+++ b/tests/testlib.bash
@@ -726,6 +726,9 @@ function installEclipse_archive() {
     else
       tar -xf "$archive"
     fi
+    # disable launching of browser with donate page, see:
+    # https://www.eclipse.org/forums/index.php/t/1104324/
+    echo "-Dorg.eclipse.oomph.setup.donate=false" >> "$Eclipse_DIR"/eclipse.ini
   fi
 }
 


### PR DESCRIPTION
Our infra shows problem with hanged GUITests on fedora. I looked into that and turns out that eclipse launches firefox with donate page there. Firefox does not get killed and is blocking job, because it is connected to pipe of `tee` command.

This adds configuration, which disables opening of donation page. It seems to fix the hang problem on fedora.