### PR TITLE
Fix dnf history commands to work on fedora

### DIFF
--- a/tests/testlib.bash
+++ b/tests/testlib.bash
@@ -148,8 +148,8 @@ function dednfyum() {
   # thus removing also the,
   # and restoring alternatives as in install rpms
   if which dnf ; then
-    sudo  dnf history info 0 | grep "${1}"
-    sudo  dnf history undo 0 -y --skip-broken
+    sudo  dnf history info last | grep "${1}"
+    sudo  dnf history undo last -y
     sudo  dnf remove -y "$@" || true # to double check the evil...
   elif which yum ; then
     # shellcheck disable=SC2155


### PR DESCRIPTION
Fixed dnf history commands to work on fedora. Argument `0` does not match anything on fedora. Also `--skip-broken` is no longer supported by recent dnf.

Fixed by using argument `last` instead of `0` in dnf history. (found in [article](https://www.putorius.net/dnf-history.html), tested on f42 and rhel-8) Yum on rhel-7 does not support argument `last`, so there code kept as it is.